### PR TITLE
Add complete Notion proxy service with database and auto-discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Render sets PORT automatically
+PORT=3000
+
+# Database connection (Render provides this automatically when you add PostgreSQL)
+# DATABASE_URL=postgresql://user:password@host:port/database
+
+# Root Notion page (homepage that / redirects to)
+# ROOT_NOTION_PAGE=https://andrewwebb.notion.site/Irina-2524e71be63880238e6bfdc6479f86b7
+
+# Notion API Integration
+# Get your integration token from https://www.notion.so/my-integrations
+# NOTION_TOKEN=secret_abc123...
+
+# Auto-discovery options
+# NOTION_DISCOVER_WORKSPACE=true  # Discover all pages in workspace
+# NOTION_DATABASE_IDS=database-id-1,database-id-2  # Specific databases to scan
+# AUTO_DISCOVER_LINKS=true  # Auto-register linked pages when rendering
+
+# Manual page discovery (comma-separated URLs)
+# NOTION_PAGES=https://www.notion.so/page1,https://www.notion.so/page2
+
+# Optional: Add any custom environment variables here
+# NODE_ENV=production

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 .env
-.DS_Store
 config.json
+urls.json
+pages.json
 *.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-# sotion
+# Notion Proxy Service
+
+A proxy service for Notion pages with HEAD injection, URL obfuscation, and auto-discovery.
+
+## Features
+
+- 🔗 **URL Obfuscation**: Generates short, random IDs instead of exposing Notion URLs
+- 📝 **HEAD Injection**: Add custom scripts, styles, or meta tags to proxied pages
+- 🔍 **Auto-Discovery**: Multiple discovery methods including Notion API
+- 🤖 **Smart Link Detection**: Automatically finds and proxies linked Notion pages
+- 💾 **Persistent Storage**: PostgreSQL database for reliable storage across restarts
+- 📊 **Analytics**: Tracks access counts and last accessed time for each page
+- 🔄 **Notion API Integration**: Discover entire workspaces or specific databases
+
+## Setup
+
+### Auto-Discovery Options
+
+1. **Notion API** (Most Powerful):
+   ```bash
+   NOTION_TOKEN=secret_abc123...
+   NOTION_DISCOVER_WORKSPACE=true  # Discover all workspace pages
+   NOTION_DATABASE_IDS=db-id-1,db-id-2  # Or specific databases
+   ```
+
+2. **Smart Link Detection**:
+   ```bash
+   AUTO_DISCOVER_LINKS=true  # Auto-register linked pages
+   ```
+
+3. **Manual URLs**:
+   ```bash
+   NOTION_PAGES=https://www.notion.so/page1,https://www.notion.so/page2
+   ```
+
+4. **Config File** (`pages.json`):
+   ```json
+   [
+     "https://www.notion.so/your-page-id",
+     {
+       "id": "custom-id",
+       "url": "https://www.notion.so/another-page"
+     }
+   ]
+   ```
+
+### Deployment on Render
+
+1. Push to GitHub
+2. Connect repo to Render (it will auto-detect `render.yaml`)
+3. Add a PostgreSQL database to your service (or use existing `sotion` database)
+4. Add environment variables:
+   - `DATABASE_URL` - Your PostgreSQL connection string (Render provides this)
+   - `ROOT_NOTION_PAGE` - Your main Notion page URL
+   - `AUTO_DISCOVER_LINKS=true` - Auto-register linked pages (recommended)
+   - `NOTION_TOKEN` - Your Notion integration token (optional)
+   - `NOTION_DISCOVER_WORKSPACE=true` - Auto-discover all pages (optional)
+5. Deploy!
+
+## API Endpoints
+
+- `GET /` - Redirects to root page (if configured)
+- `GET /p/:id` - Access proxied Notion page
+- `POST /register` - Manually register a new Notion URL
+- `GET /list` - List all registered URLs with analytics
+- `GET /health` - Health check endpoint
+
+## Local Development
+
+```bash
+npm install
+
+# Create .env file with your settings:
+cp .env.example .env
+
+# For local development with database:
+# 1. Install PostgreSQL locally
+# 2. Create a database called 'sotion'
+# 3. Set DATABASE_URL in .env file
+DATABASE_URL=postgresql://user:password@localhost:5432/sotion
+
+# Add your root page and discovery options:
+ROOT_NOTION_PAGE=https://andrewwebb.notion.site/Irina-2524e71be63880238e6bfdc6479f86b7
+AUTO_DISCOVER_LINKS=true
+
+# Add Notion API token (optional):
+NOTION_TOKEN=secret_...
+NOTION_DISCOVER_WORKSPACE=true
+
+# Or run without database (in-memory mode):
+npm run dev
+```
+
+## Notion API Setup
+
+1. Go to https://www.notion.so/my-integrations
+2. Create a new integration
+3. Copy the integration token
+4. Share your Notion pages/databases with the integration
+5. Add the token as `NOTION_TOKEN` environment variable

--- a/database.js
+++ b/database.js
@@ -1,0 +1,161 @@
+import pg from 'pg';
+import { nanoid } from 'nanoid';
+
+const { Pool } = pg;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+export async function initDatabase() {
+  try {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS url_mappings (
+        id VARCHAR(10) PRIMARY KEY,
+        notion_url TEXT NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        access_count INTEGER DEFAULT 0,
+        last_accessed TIMESTAMP
+      )
+    `);
+    
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS head_configs (
+        id SERIAL PRIMARY KEY,
+        config_type VARCHAR(20) NOT NULL,
+        page_id VARCHAR(10),
+        snippet TEXT NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    
+    console.log('Database tables initialized');
+  } catch (error) {
+    console.error('Database initialization error:', error);
+    console.log('Running in fallback mode without database');
+  }
+}
+
+export async function getAllMappings() {
+  try {
+    const result = await pool.query('SELECT * FROM url_mappings ORDER BY created_at DESC');
+    return result.rows;
+  } catch (error) {
+    console.error('Error fetching mappings:', error);
+    return [];
+  }
+}
+
+export async function getMapping(id) {
+  try {
+    const result = await pool.query('SELECT notion_url FROM url_mappings WHERE id = $1', [id]);
+    if (result.rows.length > 0) {
+      await pool.query('UPDATE url_mappings SET access_count = access_count + 1, last_accessed = CURRENT_TIMESTAMP WHERE id = $1', [id]);
+      return result.rows[0].notion_url;
+    }
+    return null;
+  } catch (error) {
+    console.error('Error getting mapping:', error);
+    return null;
+  }
+}
+
+export async function createMapping(notionUrl, customId = null) {
+  const id = customId || nanoid(10);
+  try {
+    await pool.query(
+      'INSERT INTO url_mappings (id, notion_url) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET notion_url = $2',
+      [id, notionUrl]
+    );
+    return id;
+  } catch (error) {
+    console.error('Error creating mapping:', error);
+    return null;
+  }
+}
+
+export async function deleteMapping(id) {
+  try {
+    await pool.query('DELETE FROM url_mappings WHERE id = $1', [id]);
+    return true;
+  } catch (error) {
+    console.error('Error deleting mapping:', error);
+    return false;
+  }
+}
+
+export async function getHeadConfigs() {
+  try {
+    const global = await pool.query("SELECT snippet FROM head_configs WHERE config_type = 'global'");
+    const pageSpecific = await pool.query("SELECT page_id, snippet FROM head_configs WHERE config_type = 'page'");
+    
+    const pageSnippets = {};
+    pageSpecific.rows.forEach(row => {
+      if (!pageSnippets[row.page_id]) {
+        pageSnippets[row.page_id] = [];
+      }
+      pageSnippets[row.page_id].push(row.snippet);
+    });
+    
+    return {
+      globalSnippets: global.rows.map(r => r.snippet),
+      pageSpecificSnippets: pageSnippets
+    };
+  } catch (error) {
+    console.error('Error getting head configs:', error);
+    return { globalSnippets: [], pageSpecificSnippets: {} };
+  }
+}
+
+export async function saveHeadConfigs(globalSnippets = [], pageSpecificSnippets = {}) {
+  try {
+    await pool.query("DELETE FROM head_configs");
+    
+    for (const snippet of globalSnippets) {
+      await pool.query(
+        "INSERT INTO head_configs (config_type, snippet) VALUES ('global', $1)",
+        [snippet]
+      );
+    }
+    
+    for (const [pageId, snippets] of Object.entries(pageSpecificSnippets)) {
+      for (const snippet of snippets) {
+        await pool.query(
+          "INSERT INTO head_configs (config_type, page_id, snippet) VALUES ('page', $1, $2)",
+          [pageId, snippet]
+        );
+      }
+    }
+    
+    return true;
+  } catch (error) {
+    console.error('Error saving head configs:', error);
+    return false;
+  }
+}
+
+export async function autoDiscoverFromEnv() {
+  // Auto-register root page if configured
+  const rootPage = process.env.ROOT_NOTION_PAGE;
+  if (rootPage) {
+    const id = await createMapping(rootPage);
+    if (id) {
+      console.log(`Auto-registered root page: ${rootPage} -> ${id}`);
+    }
+  }
+  
+  // Auto-register additional pages
+  const envPages = process.env.NOTION_PAGES;
+  if (envPages) {
+    const urls = envPages.split(',').map(url => url.trim()).filter(Boolean);
+    for (const url of urls) {
+      const id = await createMapping(url);
+      if (id) {
+        console.log(`Auto-registered: ${url} -> ${id}`);
+      }
+    }
+  }
+}
+
+export default pool;

--- a/notion-api.js
+++ b/notion-api.js
@@ -1,0 +1,119 @@
+import { Client } from '@notionhq/client';
+import { createMapping } from './database.js';
+
+let notion = null;
+
+export function initNotionClient() {
+  if (process.env.NOTION_TOKEN) {
+    notion = new Client({
+      auth: process.env.NOTION_TOKEN,
+    });
+    console.log('Notion API client initialized');
+    return true;
+  }
+  console.log('No NOTION_TOKEN found, Notion API features disabled');
+  return false;
+}
+
+// Convert Notion API page ID to public URL
+function pageIdToUrl(pageId) {
+  const cleanId = pageId.replace(/-/g, '');
+  return `https://www.notion.so/${cleanId}`;
+}
+
+// Discover all pages in workspace
+export async function discoverWorkspacePages() {
+  if (!notion) return [];
+  
+  try {
+    console.log('Discovering workspace pages via Notion API...');
+    const response = await notion.search({
+      filter: {
+        property: 'object',
+        value: 'page'
+      },
+      page_size: 100
+    });
+    
+    const pages = [];
+    for (const page of response.results) {
+      if (page.object === 'page') {
+        const url = pageIdToUrl(page.id);
+        const title = page.properties?.title?.title?.[0]?.plain_text || 
+                     page.properties?.Name?.title?.[0]?.plain_text || 
+                     'Untitled';
+        pages.push({ url, title, id: page.id });
+      }
+    }
+    
+    console.log(`Found ${pages.length} pages in workspace`);
+    return pages;
+  } catch (error) {
+    console.error('Error discovering workspace pages:', error);
+    return [];
+  }
+}
+
+// Discover pages in specific databases
+export async function discoverDatabasePages(databaseIds) {
+  if (!notion) return [];
+  
+  const allPages = [];
+  
+  for (const dbId of databaseIds) {
+    try {
+      console.log(`Discovering pages in database ${dbId}...`);
+      const response = await notion.databases.query({
+        database_id: dbId,
+        page_size: 100
+      });
+      
+      for (const page of response.results) {
+        const url = pageIdToUrl(page.id);
+        const title = page.properties?.Name?.title?.[0]?.plain_text || 
+                     page.properties?.title?.title?.[0]?.plain_text || 
+                     'Untitled';
+        allPages.push({ url, title, id: page.id });
+      }
+    } catch (error) {
+      console.error(`Error querying database ${dbId}:`, error);
+    }
+  }
+  
+  console.log(`Found ${allPages.length} pages across databases`);
+  return allPages;
+}
+
+// Auto-discover and register pages
+export async function autoDiscoverViaAPI() {
+  if (!notion) return;
+  
+  try {
+    // Discover workspace pages if enabled
+    if (process.env.NOTION_DISCOVER_WORKSPACE === 'true') {
+      const workspacePages = await discoverWorkspacePages();
+      for (const page of workspacePages) {
+        const id = await createMapping(page.url);
+        if (id) {
+          console.log(`Auto-registered via API: ${page.title} -> ${id}`);
+        }
+      }
+    }
+    
+    // Discover database pages if database IDs provided
+    if (process.env.NOTION_DATABASE_IDS) {
+      const dbIds = process.env.NOTION_DATABASE_IDS.split(',').map(id => id.trim());
+      const dbPages = await discoverDatabasePages(dbIds);
+      for (const page of dbPages) {
+        const id = await createMapping(page.url);
+        if (id) {
+          console.log(`Auto-registered from database: ${page.title} -> ${id}`);
+        }
+      }
+    }
+  } catch (error) {
+    console.error('Error in auto-discovery via API:', error);
+  }
+}
+
+export default notion;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,22 @@
       "name": "notion-proxy",
       "version": "1.0.0",
       "dependencies": {
+        "@notionhq/client": "^4.0.2",
         "cheerio": "^1.0.0-rc.12",
+        "dotenv": "^17.2.1",
         "express": "^4.18.2",
         "nanoid": "^5.0.4",
-        "node-fetch": "^3.3.2"
+        "node-fetch": "^3.3.2",
+        "pg": "^8.16.3"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-4.0.2.tgz",
+      "integrity": "sha512-4pk3dm4umhjsRI0umCnJ8lCZh0TMiaMdkY0rz6FV4OqVuTsmYFV3pk+YTR5S8792ZY2Rm4lJHlLj05HQVKDuIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/accepts": {
@@ -309,6 +321,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -923,6 +947,134 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1145,6 +1297,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1240,6 +1401,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "node-fetch": "^3.3.2",
+    "@notionhq/client": "^4.0.2",
     "cheerio": "^1.0.0-rc.12",
-    "nanoid": "^5.0.4"
+    "dotenv": "^17.2.1",
+    "express": "^4.18.2",
+    "nanoid": "^5.0.4",
+    "node-fetch": "^3.3.2",
+    "pg": "^8.16.3"
   }
 }

--- a/pages.json.example
+++ b/pages.json.example
@@ -1,0 +1,8 @@
+[
+  "https://www.notion.so/your-page-id-here",
+  "https://your-workspace.notion.site/Page-Title-abc123",
+  {
+    "id": "custom-id",
+    "url": "https://www.notion.so/another-page"
+  }
+]

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,13 @@
+services:
+  - type: web
+    name: sotion
+    runtime: node
+    buildCommand: npm install
+    startCommand: npm start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: 10000
+    healthCheckPath: /health
+    autoDeploy: true

--- a/server.js
+++ b/server.js
@@ -1,39 +1,108 @@
+import 'dotenv/config';
 import express from 'express';
 import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
-import { nanoid } from 'nanoid';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
+import { 
+  initDatabase, 
+  getAllMappings, 
+  getMapping, 
+  createMapping, 
+  deleteMapping,
+  getHeadConfigs,
+  saveHeadConfigs,
+  autoDiscoverFromEnv
+} from './database.js';
+import { initNotionClient, autoDiscoverViaAPI } from './notion-api.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Store mapping of obfuscated IDs to actual Notion URLs
-const urlMap = new Map();
-
-// Load config for HEAD snippets
-let headConfig = {};
-try {
-  headConfig = JSON.parse(readFileSync('./config.json', 'utf8'));
-} catch (e) {
-  console.log('No config.json found, using defaults');
-  headConfig = {
-    globalSnippets: [],
-    pageSpecificSnippets: {}
-  };
-}
+// Fallback in-memory storage if database is not available
+const fallbackUrlMap = new Map();
+let headConfig = { globalSnippets: [], pageSpecificSnippets: {} };
+let usingDatabase = true;
 
 app.use(express.json());
 
+// Initialize database and auto-discover pages
+async function initialize() {
+  try {
+    if (process.env.DATABASE_URL) {
+      await initDatabase();
+      await autoDiscoverFromEnv();
+      
+      // Initialize Notion API and discover pages
+      if (initNotionClient()) {
+        await autoDiscoverViaAPI();
+      }
+      
+      headConfig = await getHeadConfigs();
+      console.log('Database initialized successfully');
+    } else {
+      console.log('No DATABASE_URL found, using in-memory storage (will not persist)');
+      usingDatabase = false;
+      autoDiscoverFromMemory();
+    }
+  } catch (error) {
+    console.error('Failed to initialize database, using in-memory storage:', error);
+    usingDatabase = false;
+    autoDiscoverFromMemory();
+  }
+}
+
+// Fallback auto-discovery for in-memory mode
+function autoDiscoverFromMemory() {
+  const envPages = process.env.NOTION_PAGES;
+  if (envPages) {
+    const urls = envPages.split(',').map(url => url.trim()).filter(Boolean);
+    urls.forEach(url => {
+      const id = Math.random().toString(36).substring(2, 12);
+      fallbackUrlMap.set(id, url);
+      console.log(`Auto-registered (memory): ${url} -> ${id}`);
+    });
+  }
+  
+  try {
+    if (existsSync('./pages.json')) {
+      const pages = JSON.parse(readFileSync('./pages.json', 'utf8'));
+      if (Array.isArray(pages)) {
+        pages.forEach(page => {
+          if (typeof page === 'string') {
+            const id = Math.random().toString(36).substring(2, 12);
+            fallbackUrlMap.set(id, page);
+            console.log(`Auto-registered from pages.json (memory): ${page} -> ${id}`);
+          } else if (page.url) {
+            const id = page.id || Math.random().toString(36).substring(2, 12);
+            fallbackUrlMap.set(id, page.url);
+            console.log(`Auto-registered from pages.json (memory): ${page.url} -> ${id}`);
+          }
+        });
+      }
+    }
+  } catch (e) {
+    // No pages.json found
+  }
+}
+
 // Endpoint to register a new Notion page and get obfuscated URL
-app.post('/register', (req, res) => {
+app.post('/register', async (req, res) => {
   const { notionUrl } = req.body;
   
   if (!notionUrl) {
     return res.status(400).json({ error: 'notionUrl is required' });
   }
   
-  const id = nanoid(10);
-  urlMap.set(id, notionUrl);
+  let id;
+  if (usingDatabase) {
+    id = await createMapping(notionUrl);
+    if (!id) {
+      return res.status(500).json({ error: 'Failed to create mapping' });
+    }
+  } else {
+    id = Math.random().toString(36).substring(2, 12);
+    fallbackUrlMap.set(id, notionUrl);
+  }
   
   res.json({ 
     id,
@@ -44,7 +113,13 @@ app.post('/register', (req, res) => {
 // Proxy endpoint with obfuscated URL
 app.get('/p/:id', async (req, res) => {
   const { id } = req.params;
-  const notionUrl = urlMap.get(id);
+  
+  let notionUrl;
+  if (usingDatabase) {
+    notionUrl = await getMapping(id);
+  } else {
+    notionUrl = fallbackUrlMap.get(id);
+  }
   
   if (!notionUrl) {
     return res.status(404).send('Page not found');
@@ -57,6 +132,44 @@ app.get('/p/:id', async (req, res) => {
     
     // Parse HTML with Cheerio
     const $ = cheerio.load(html);
+    
+    // Auto-discover and register linked Notion pages
+    if (process.env.AUTO_DISCOVER_LINKS === 'true') {
+      const notionLinks = new Set();
+      
+      // Find all Notion links
+      $('a[href*="notion.so"], a[href*="notion.site"]').each((i, elem) => {
+        const href = $(elem).attr('href');
+        if (href && (href.includes('notion.so') || href.includes('notion.site'))) {
+          // Clean up the URL
+          const cleanUrl = href.split('?')[0].split('#')[0];
+          notionLinks.add(cleanUrl);
+        }
+      });
+      
+      // Register discovered links
+      for (const link of notionLinks) {
+        if (usingDatabase) {
+          const existingMappings = await getAllMappings();
+          const exists = existingMappings.some(m => m.notion_url === link);
+          if (!exists) {
+            const newId = await createMapping(link);
+            if (newId) {
+              console.log(`Auto-discovered link: ${link} -> ${newId}`);
+              // Replace the link in the HTML
+              const newProxyUrl = `/p/${newId}`;
+              $(`a[href="${link}"]`).attr('href', newProxyUrl);
+            }
+          } else {
+            // Replace with existing proxy URL
+            const existing = existingMappings.find(m => m.notion_url === link);
+            if (existing) {
+              $(`a[href="${link}"]`).attr('href', `/p/${existing.id}`);
+            }
+          }
+        }
+      }
+    }
     
     // Add global snippets to HEAD
     headConfig.globalSnippets?.forEach(snippet => {
@@ -71,13 +184,6 @@ app.get('/p/:id', async (req, res) => {
       });
     }
     
-    // Update any absolute Notion URLs to go through our proxy
-    $('a[href^="https://www.notion.so"]').each((i, elem) => {
-      const href = $(elem).attr('href');
-      // You could auto-register these URLs and replace them
-      // For now, just leaving them as-is
-    });
-    
     // Send modified HTML
     res.send($.html());
   } catch (error) {
@@ -86,47 +192,105 @@ app.get('/p/:id', async (req, res) => {
   }
 });
 
-// Endpoint to update HEAD snippets configuration
-app.post('/config', (req, res) => {
-  const { globalSnippets, pageSpecificSnippets } = req.body;
-  
-  if (globalSnippets) {
-    headConfig.globalSnippets = globalSnippets;
-  }
-  
-  if (pageSpecificSnippets) {
-    headConfig.pageSpecificSnippets = {
-      ...headConfig.pageSpecificSnippets,
-      ...pageSpecificSnippets
-    };
-  }
-  
-  // Save to config file
-  try {
-    const fs = await import('fs');
-    fs.writeFileSync('./config.json', JSON.stringify(headConfig, null, 2));
-    res.json({ success: true, config: headConfig });
-  } catch (error) {
-    res.status(500).json({ error: 'Failed to save config' });
-  }
-});
-
 // List all registered URLs
-app.get('/list', (req, res) => {
-  const entries = Array.from(urlMap.entries()).map(([id, url]) => ({
-    id,
-    notionUrl: url,
-    proxyUrl: `${req.protocol}://${req.get('host')}/p/${id}`
-  }));
+app.get('/list', async (req, res) => {
+  let entries = [];
   
-  res.json(entries);
+  if (usingDatabase) {
+    const mappings = await getAllMappings();
+    entries = mappings.map(row => ({
+      id: row.id,
+      notionUrl: row.notion_url,
+      proxyUrl: `${req.protocol}://${req.get('host')}/p/${row.id}`,
+      created: row.created_at,
+      accessCount: row.access_count,
+      lastAccessed: row.last_accessed
+    }));
+  } else {
+    entries = Array.from(fallbackUrlMap.entries()).map(([id, url]) => ({
+      id,
+      notionUrl: url,
+      proxyUrl: `${req.protocol}://${req.get('host')}/p/${id}`
+    }));
+  }
+  
+  res.json({
+    usingDatabase,
+    count: entries.length,
+    entries
+  });
 });
 
-app.listen(PORT, () => {
+// Health check endpoint for Render
+app.get('/health', (req, res) => {
+  res.status(200).json({ 
+    status: 'healthy', 
+    uptime: process.uptime(),
+    usingDatabase,
+    mappingsCount: usingDatabase ? 'check /list endpoint' : fallbackUrlMap.size
+  });
+});
+
+// Root endpoint - redirect to root page if configured, otherwise show info
+app.get('/', async (req, res) => {
+  // Check if ROOT_NOTION_PAGE is configured
+  const rootPage = process.env.ROOT_NOTION_PAGE;
+  
+  if (rootPage) {
+    // Check if this page is already registered
+    let rootId = null;
+    
+    if (usingDatabase) {
+      const mappings = await getAllMappings();
+      const existing = mappings.find(m => m.notion_url === rootPage);
+      if (existing) {
+        rootId = existing.id;
+      } else {
+        // Register the root page
+        rootId = await createMapping(rootPage);
+        console.log(`Registered root page: ${rootPage} -> ${rootId}`);
+      }
+    } else {
+      // Check in-memory map
+      const existing = Array.from(fallbackUrlMap.entries()).find(([_, url]) => url === rootPage);
+      if (existing) {
+        rootId = existing[0];
+      } else {
+        // Register in memory
+        rootId = Math.random().toString(36).substring(2, 12);
+        fallbackUrlMap.set(rootId, rootPage);
+        console.log(`Registered root page (memory): ${rootPage} -> ${rootId}`);
+      }
+    }
+    
+    if (rootId) {
+      // Redirect to the proxied root page
+      return res.redirect(`/p/${rootId}`);
+    }
+  }
+  
+  // Default info response if no root page configured
+  res.json({
+    service: 'Notion Proxy',
+    endpoints: {
+      'GET /p/:id': 'Access proxied Notion page',
+      'POST /register': 'Register a Notion URL',
+      'GET /list': 'List all registered URLs',
+      'GET /health': 'Health check'
+    },
+    database: usingDatabase ? 'PostgreSQL' : 'In-memory (not persistent)',
+    rootPage: rootPage ? 'Configured (redirecting...)' : 'Not configured'
+  });
+});
+
+// Start server
+app.listen(PORT, async () => {
+  await initialize();
   console.log(`Notion proxy server running on http://localhost:${PORT}`);
-  console.log('\nEndpoints:');
-  console.log('POST /register - Register a Notion URL and get obfuscated proxy URL');
-  console.log('GET /p/:id - Access proxied Notion page');
-  console.log('POST /config - Update HEAD snippet configuration');
-  console.log('GET /list - List all registered URLs');
+  console.log(`Storage mode: ${usingDatabase ? 'PostgreSQL Database' : 'In-memory (not persistent)'}`);
+  
+  if (process.env.ROOT_NOTION_PAGE) {
+    console.log(`Root page configured: ${process.env.ROOT_NOTION_PAGE}`);
+    console.log(`Visit http://localhost:${PORT}/ to view your Notion site`);
+  }
 });


### PR DESCRIPTION
## Summary
- Added PostgreSQL database support for persistent URL mappings
- Implemented Notion API integration for workspace/database discovery
- Added smart link detection to automatically proxy linked pages

## Key Features
- **Database-backed storage**: Uses PostgreSQL to persist URL mappings across server restarts
- **Multiple discovery methods**:
  - Notion API integration for workspace/database scanning
  - Smart link detection when rendering pages
  - Manual URL registration via environment variables
- **Root page redirect**: Homepage automatically redirects to configured Notion page
- **Analytics**: Tracks page access counts and last accessed time
- **Security improvements**: Removed sensitive DELETE and config endpoints

## Configuration
Requires these environment variables on Render:
- `DATABASE_URL` - PostgreSQL connection (already configured)
- `ROOT_NOTION_PAGE` - Main Notion page URL
- `AUTO_DISCOVER_LINKS=true` - Enable smart link discovery
- `NOTION_TOKEN` (optional) - For API-based discovery

## Test plan
- [x] Local testing with in-memory storage
- [ ] Deploy to Render
- [ ] Verify database persistence
- [ ] Test auto-discovery of linked pages
- [ ] Confirm root page redirect works