### PR TITLE
Fix root page configuration status display

### DIFF
--- a/server.js
+++ b/server.js
@@ -738,7 +738,7 @@ app.get('/', async (req, res) => {
       'POST /cache/clear': 'Clear the cache'
     },
     database: usingDatabase ? 'PostgreSQL' : 'In-memory (not persistent)',
-    rootPage: rootPage ? 'Not configured' : 'Not configured'
+    rootPage: rootPage ? 'Configured' : 'Not configured'
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixed incorrect display of root page configuration status in the API response
- The ternary operator was showing "Not configured" regardless of whether ROOT_NOTION_PAGE was set

## Changes
- Updated server.js line 741 to correctly display "Configured" when ROOT_NOTION_PAGE environment variable is set
- Previously showed "Not configured" in both cases due to logic error

## Test plan
- [x] Set ROOT_NOTION_PAGE environment variable
- [x] Start the server
- [x] Visit root route without a root page configured - should show "Not configured"
- [x] Visit root route with ROOT_NOTION_PAGE set - should show "Configured"